### PR TITLE
add reconnecting, error detection, option for connection notifications and fix images

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,10 @@
 XBMC-MQTT
 =========
 
-Copy script.service.mosquitto/ to ~/.xbmc/addons/
+Copy **script.service.mosquitto/** to **~/.xbmc/addons/**
 
-In the Addons menu, go to Services/Mosquitto and fill in the details
-of your broker and desired topic to listen to.
+In the Addons menu, go to Services/Mosquitto and fill in the details of your broker and desired topic to listen to.
 
 Send a message with something like:
 
-  $ mosquitto_pub -h myhost.net -t xbmc/messages -m '{"sub":"A subject line", "txt":"A message to display","img":"url://for/image","delay":"5000"}'
-
-Bugs
-passing unexpected values in the JSON string will crash the addon
-the addon doesn't reconnect automatically (maybe it shouldn't)
-there is very little error detection
-input validation is pretty much nonexistent too
-
-
-
+    $ mosquitto_pub -h myhost.net -t xbmc/messages -m '{"sub":"A subject line", "txt":"A message to display","img":"url://for/image","delay":"5000"}'

--- a/script.service.mosquitto/default.py
+++ b/script.service.mosquitto/default.py
@@ -17,25 +17,48 @@ __resource__    = xbmc.translatePath(os.path.join(__cwd__, 'resources'))
 # loading message
 xbmc.log("##### [%s] - Version: %s" % (__scriptname__,__version__,),level=xbmc.LOGDEBUG )
 
-def stdmessage(sub, txt, img='', delay=5000):
-    xbmc.executebuiltin('Notification(%s,%s,%s,%s)' % (sub, txt, delay, img))
+connected = False
+
+
+def stdmessage(sub='', txt='', img='DefaultIconInfo.png', delay=5000):
+    if sub:
+        xbmc.executebuiltin('Notification("%s","%s","%s","%s")' % (sub, txt, delay, img))
+    else:
+        xbmc.log("EE: [%s] - no header for notification specified" % (__scriptname__))
+
 
 def on_message(mosq, obj, msg):
     try:
         u = json.loads(msg.payload)
     except:
         xbmc.log("EE: [%s] - could not parse JSON (%s)" % (__scriptname__, msg.payload))
+        return
+
     # okay, looks like we have valid JSON
-    stdmessage(**u)
+    try:
+        stdmessage(**u)
+    except:
+        xbmc.log("EE: [%s] - error in JSON (%s)" % (__scriptname__, msg.payload))
+
 
 def on_connect(mosq, obj, rc):
+    global connected
     if rc == 0:
         xbmc.log("II: [%s] - connected to broker" % (__scriptname__))
-        xbmc.executebuiltin('Notification(xbmc-mqtt,Connected to MQTT broker,5000,special://skin/media/DefaultIconInfo.png)')
+        if conmsgs:
+            xbmc.executebuiltin('Notification(xbmc-mqtt,Connected to MQTT broker,5000,DefaultIconInfo.png)')
+        connected = True
+
+        mqtt.subscribe(topic)
+
 
 def on_disconnect(mosq, obj, msg):
+    global connected
     xbmc.log("II: [%s] - disconnected from broker" % (__scriptname__))
-    xbmc.executebuiltin('Notification(xbmc-mqtt,Disconnected from MQTT broker,5000,special://skin/media/DefaultIconWarning.png)')
+    if conmsgs:
+        xbmc.executebuiltin('Notification(xbmc-mqtt,Disconnected from MQTT broker,5000,DefaultIconWarning.png)')
+    connected = False
+
 
 if __name__ == "__main__":
     # get the basic settings
@@ -46,22 +69,37 @@ if __name__ == "__main__":
     host = s('hostname')
     port = int(s('port'))
     topic = s('topic')
+    conmsgs = 'true' in s('conmsgs')
 
     # create a Mosquitto client, using the XBMC Device name as a label
-    mqtt = mosquitto.Mosquitto(xbmc.getInfoLabel("System.FriendlyName"))
+    mqtt = mosquitto.Mosquitto(xbmc.getInfoLabel("System.FriendlyName") + "_" + xbmc.getInfoLabel("Network.IPAddress"))
     mqtt.username_pw_set(s('username'), s('password'))
-    try:
-        mqtt.connect(host, port, 60)
-    except:
-        xbmc.log("EE: [%s] - could not connect to MQTT broker (%s, %d)" % (__scriptname__, host, port))
-        xbmc.executebuiltin('Notification(xbmc-mqtt,Could not connect to MQTT broker %s:%s,5000)' % (host, port))
-        sys.exit(1)
-
-    mqtt.subscribe(topic)
     mqtt.on_message = on_message
     mqtt.on_connect = on_connect
     mqtt.on_disconnect = on_disconnect
 
-    while not xbmc.abortRequested:
-        mqtt.loop(timeout=1)
+    while True:
+        if connected:
+            try:
+                mqtt.loop(timeout=1)
+            except:
+                xbmc.log("EE: [%s] - connection lost" % (__scriptname__))
+                if conmsgs:
+                    xbmc.executebuiltin('Notification(xbmc-mqtt,Connection lost,5000,DefaultIconError.png)')
+                connected = False
+        else:
+            try:
+                mqtt.connect(host, port, 60)
+            except:
+                xbmc.log("EE: [%s] - could not connect to MQTT broker (%s, %d)" % (__scriptname__, host, port))
+                if conmsgs:
+                    xbmc.executebuiltin('Notification(xbmc-mqtt,"Could not connect to MQTT broker %s:%s",5000,DefaultIconError.png)' % (host, port))
+                xbmc.sleep(10000)
+            else:
+                connected = True
+
+        if xbmc.abortRequested:
+            xbmc.log("II: [%s] - abort requested" % (__scriptname__))
+            break
+
     mqtt.disconnect()

--- a/script.service.mosquitto/default.py
+++ b/script.service.mosquitto/default.py
@@ -45,7 +45,7 @@ def on_connect(mosq, obj, rc):
     global connected
     if rc == 0:
         xbmc.log("II: [%s] - connected to broker" % (__scriptname__))
-        if conmsgs:
+        if connmsgs:
             xbmc.executebuiltin('Notification(xbmc-mqtt,Connected to MQTT broker,5000,DefaultIconInfo.png)')
         connected = True
 
@@ -55,7 +55,7 @@ def on_connect(mosq, obj, rc):
 def on_disconnect(mosq, obj, msg):
     global connected
     xbmc.log("II: [%s] - disconnected from broker" % (__scriptname__))
-    if conmsgs:
+    if connmsgs:
         xbmc.executebuiltin('Notification(xbmc-mqtt,Disconnected from MQTT broker,5000,DefaultIconWarning.png)')
     connected = False
 
@@ -69,7 +69,7 @@ if __name__ == "__main__":
     host = s('hostname')
     port = int(s('port'))
     topic = s('topic')
-    conmsgs = 'true' in s('conmsgs')
+    connmsgs = 'true' in s('connmsgs')
 
     # create a Mosquitto client, using the XBMC Device name as a label
     mqtt = mosquitto.Mosquitto(xbmc.getInfoLabel("System.FriendlyName") + "_" + xbmc.getInfoLabel("Network.IPAddress"))
@@ -84,7 +84,7 @@ if __name__ == "__main__":
                 mqtt.loop(timeout=1)
             except:
                 xbmc.log("EE: [%s] - connection lost" % (__scriptname__))
-                if conmsgs:
+                if connmsgs:
                     xbmc.executebuiltin('Notification(xbmc-mqtt,Connection lost,5000,DefaultIconError.png)')
                 connected = False
         else:
@@ -92,7 +92,7 @@ if __name__ == "__main__":
                 mqtt.connect(host, port, 60)
             except:
                 xbmc.log("EE: [%s] - could not connect to MQTT broker (%s, %d)" % (__scriptname__, host, port))
-                if conmsgs:
+                if connmsgs:
                     xbmc.executebuiltin('Notification(xbmc-mqtt,"Could not connect to MQTT broker %s:%s",5000,DefaultIconError.png)' % (host, port))
                 xbmc.sleep(10000)
             else:

--- a/script.service.mosquitto/resources/settings.xml
+++ b/script.service.mosquitto/resources/settings.xml
@@ -7,5 +7,5 @@
 <setting label="Password" type="text" id="password" default="" option="hidden" enable="!eq(-1,)"/>
 <setting type="lsep" label="Notifications"/>
 <setting label="Topic" type="text" id="topic" default="xbmc/messages"/>
-<setting label="Display connection notifications" type="bool" id="conmsgs" default="true"/>
+<setting label="Display connection notifications" type="bool" id="connmsgs" default="true"/>
 </settings>

--- a/script.service.mosquitto/resources/settings.xml
+++ b/script.service.mosquitto/resources/settings.xml
@@ -5,6 +5,7 @@
 <setting label="Port" type="number" id="port" default="1883"/>
 <setting label="Username" type="text" id="username" default=""/>
 <setting label="Password" type="text" id="password" default="" option="hidden" enable="!eq(-1,)"/>
-<setting type="lsep" label="MQTT"/>
+<setting type="lsep" label="Notifications"/>
 <setting label="Topic" type="text" id="topic" default="xbmc/messages"/>
+<setting label="Display connection notifications" type="bool" id="conmsgs" default="true"/>
 </settings>


### PR DESCRIPTION
Big pull request with the following changes:
- reconnect to broker
- error detection
- add IP address to the client ID to prevent duplicate names
- option to show/hide connection notifications
- fix images in connection notifications
- show info icon if no image is specified
- remove warning in readme
